### PR TITLE
Fix setting of SSD1963 vertical front porch

### DIFF
--- a/middleware/legato/driver/controller/ssd1963/templates/drv_gfx_ssd1963.c.ftl
+++ b/middleware/legato/driver/controller/ssd1963/templates/drv_gfx_ssd1963.c.ftl
@@ -85,7 +85,7 @@
 #define DISP_HOR_FRONT_PORCH ${Val_HorzFrontPorch}
 #define DISP_HOR_BACK_PORCH ${Val_HorzBackPorch}
 #define DISP_VER_PULSE_WIDTH ${Val_VertPulseWidth}
-#define DISP_VER_FRONT_PORCH ${Val_HorzFrontPorch}
+#define DISP_VER_FRONT_PORCH ${Val_VertFrontPorch}
 #define DISP_VER_BACK_PORCH ${Val_VertBackPorch}
 
 #define PIXEL_BUFFER_COLOR_MODE GFX_COLOR_MODE_RGB_565


### PR DESCRIPTION
The value for the horizontal front porch was being used to define the vertical front porch.